### PR TITLE
Redis DB 연결 코드 리팩터링

### DIFF
--- a/database/redis.js
+++ b/database/redis.js
@@ -13,22 +13,11 @@ const dbConfig = {
       : process.env.CACHE_TEST_DB,
 }
 
-const redisClient = redis.createClient({
+export const redisClient = redis.createClient({
   url: `redis://:${dbConfig.password}@${dbConfig.host}:${dbConfig.port}/${dbConfig.database}`,
 })
-
 ;(async () => {
   await redisClient.connect()
 })()
 
 console.log(`Created Redis Connection to ${dbConfig.host}:${dbConfig.port}`)
-
-export const getFromRedis = async (key) => {
-  const result = await redisClient.get(key)
-
-  return result
-}
-
-export const setToRedis = async (key, value) => {
-  await redisClient.set(key, value)
-}

--- a/database/redis.js
+++ b/database/redis.js
@@ -16,6 +16,8 @@ const dbConfig = {
 export const redisClient = redis.createClient({
   url: `redis://:${dbConfig.password}@${dbConfig.host}:${dbConfig.port}/${dbConfig.database}`,
 })
+
+// 코드 최상단에서 await을 사용하기 위해 async 익명 함수를 만들어 바로 호출하는 방식
 ;(async () => {
   await redisClient.connect()
 })()

--- a/router/test.js
+++ b/router/test.js
@@ -5,7 +5,6 @@ import { configDotenv } from 'dotenv'
 import { useMongoModel } from '../database/mongodb'
 import { testSchema } from '../models/test'
 import { redisClient } from '@database/redis'
-import { getFromRedis, setToRedis } from '../database/redis'
 import * as validation from '@utility/validation'
 
 configDotenv()
@@ -37,8 +36,8 @@ testRouter.get('/redis/connection', async (req, res) => {
     `getting data from ... ${process.env.CACHE_HOST}:${process.env.CACHE_PORT}`,
   )
 
-  await setToRedis('test', 'connection successful')
-  const result = await getFromRedis('test')
+  await redisClient.set('test', 'connection successful')
+  const result = await redisClient.get('test')
 
   res.send(`connection successful, test result: ${result}`)
 })


### PR DESCRIPTION
1. `@router/redis`에서 `redisClient`를 직접 export하도록 수정
2. 테스트용 API 핸들러에 반영
3. 비동기함수 호출 코드에 주석 추가