### PR TITLE
validation throw 및 숫자 입력 처리 방식 수정

### DIFF
--- a/middleware/notice.js
+++ b/middleware/notice.js
@@ -34,7 +34,7 @@ export const validateNoticePathIndex = (req, res, next) => {
     noticeId,
     'noticeId',
     validation.checkExist(),
-    validation.checkIsNumber(),
+    validation.checkParsedNumberInRange(1, Infinity),
   )
 
   next()

--- a/middleware/page.js
+++ b/middleware/page.js
@@ -1,12 +1,13 @@
 import * as validation from '@utility/validation'
 
 export const validatePageNumber = (req, res, next) => {
-  const { page = 1 } = req.query
+  const { page } = req.query
 
   validation.check(
     parseInt(page),
     'page',
-    validation.checkIsInNumberRange(1, Infinity),
+    validation.checkExist(),
+    validation.checkParsedNumberInRange(1, Infinity),
   )
 
   next()

--- a/middleware/report.js
+++ b/middleware/report.js
@@ -1,24 +1,33 @@
 import * as validation from '@utility/validation'
 
 export const validateReport = (req, res, next) => {
-  const {
-    reporteeId = null,
-    isOffensive = 0,
-    isPoorManner = 0,
-    isCheating = 0,
-    note = '',
-  } = req.body
+  const { reporteeId, isOffensive, isPoorManner, isCheating, note } = req.body
 
   validation.check(
     reporteeId,
     'reporteeId',
     validation.checkExist(),
-    validation.checkIsNumber(),
+    validation.checkParsedNumberInRange(1, Infinity),
   )
 
-  validation.check(isOffensive, 'isOffensive', validation.checkIsNumber())
-  validation.check(isPoorManner, 'isPoorManner', validation.checkIsNumber())
-  validation.check(isCheating, 'isCheating', validation.checkIsNumber())
+  validation.check(
+    isOffensive,
+    'isOffensive',
+    validation.checkExist(),
+    validation.checkRegExp(/^0|1$/),
+  )
+  validation.check(
+    isPoorManner,
+    'isPoorManner',
+    validation.checkExist(),
+    validation.checkRegExp(/^0|1$/),
+  )
+  validation.check(
+    isCheating,
+    'isCheating',
+    validation.checkExist(),
+    validation.checkRegExp(/^0|1$/),
+  )
 
   if (
     isOffensive === 0 &&
@@ -36,46 +45,47 @@ export const validateReport = (req, res, next) => {
 }
 
 export const validateReportSearch = (req, res, next) => {
-  const {
-    page = 1,
-    reporterId,
-    reporteeId,
-    isOffensive,
-    isPoorManner,
-    isCheating,
-  } = req.body
+  const { reporterId, reporteeId, isOffensive, isPoorManner, isCheating } =
+    req.body
 
-  validation.check(page, 'page', validation.checkIsNumber())
   reporterId &&
-    validation.check(reporterId, 'reporterId', validation.checkIsNumber())
+    validation.check(
+      reporterId,
+      'reporterId',
+      validation.checkParsedNumberInRange(1, Infinity),
+    )
   reporteeId &&
-    validation.check(reporteeId, 'reporteeId', validation.checkIsNumber())
+    validation.check(
+      reporteeId,
+      'reporteeId',
+      validation.checkParsedNumberInRange(1, Infinity),
+    )
   isOffensive &&
-    validation.check(isOffensive, 'isOffensive', validation.checkIsNumber())
+    validation.check(
+      isOffensive,
+      'isOffensive',
+      validation.checkRegExp(/^0|1$/),
+    )
   isPoorManner &&
-    validation.check(isPoorManner, 'isPoorManner', validation.checkIsNumber())
+    validation.check(
+      isPoorManner,
+      'isPoorManner',
+      validation.checkRegExp(/^0|1$/),
+    )
   isCheating &&
-    validation.check(isCheating, 'isCheating', validation.checkIsNumber())
+    validation.check(isCheating, 'isCheating', validation.checkRegExp(/^0|1$/))
 
   next()
 }
 
 export const validateReportModification = (req, res, next) => {
-  const { reportId } = req.params
   const { reportStatus } = req.body
-
-  validation.check(
-    reportId,
-    'reportId',
-    validation.checkExist(),
-    validation.checkIsNumber(),
-  )
 
   validation.check(
     reportStatus,
     'reportStatus',
     validation.checkExist(),
-    validation.checkIsNumber(),
+    validation.checkRegExp(/^0|1$/),
   )
 
   next()
@@ -88,7 +98,7 @@ export const validateReportPathIndex = (req, res, next) => {
     reportId,
     'reportId',
     validation.checkExist(),
-    validation.checkIsNumber(),
+    validation.checkParsedNumberInRange(1, Infinity),
   )
 
   next()

--- a/middleware/report.js
+++ b/middleware/report.js
@@ -14,25 +14,25 @@ export const validateReport = (req, res, next) => {
     isOffensive,
     'isOffensive',
     validation.checkExist(),
-    validation.checkRegExp(/^0|1$/),
+    validation.checkRegExp(/^true|false$/),
   )
   validation.check(
     isPoorManner,
     'isPoorManner',
     validation.checkExist(),
-    validation.checkRegExp(/^0|1$/),
+    validation.checkRegExp(/^true|false$/),
   )
   validation.check(
     isCheating,
     'isCheating',
     validation.checkExist(),
-    validation.checkRegExp(/^0|1$/),
+    validation.checkRegExp(/^true|false$/),
   )
 
   if (
-    isOffensive === 0 &&
-    isPoorManner === 0 &&
-    isCheating === 0 &&
+    isOffensive === false &&
+    isPoorManner === false &&
+    isCheating === false &&
     note === ''
   ) {
     throw {

--- a/middleware/user.js
+++ b/middleware/user.js
@@ -1,7 +1,7 @@
 import * as validation from '@utility/validation'
 
 export const validateSignIn = (req, res, next) => {
-  const { username = null, password = null } = req.body
+  const { username, password } = req.body
 
   validation.check(
     username,

--- a/middleware/user.js
+++ b/middleware/user.js
@@ -72,7 +72,7 @@ export const validateReceiverNumber = (req, res, next) => {
     receiverNumber,
     'receiverNumber',
     validation.checkExist(),
-    validation.checkRegExp(/010-\d{4}-\d{4}/),
+    validation.checkRegExp(/^010-\d{4}-\d{4}$/),
   )
 
   next()
@@ -88,14 +88,14 @@ export const validateAuthCodeCheck = (req, res, next) => {
     authNumber,
     'authNumber',
     validation.checkExist(),
-    validation.checkRegExp(/\d{6}/),
+    validation.checkRegExp(/^\d{6}$/),
   )
 
   validation.check(
     phoneNumber,
     'phoneNumber',
     validation.checkExist(),
-    validation.checkRegExp(/010-\d{4}-\d{4}/),
+    validation.checkRegExp(/^010-\d{4}-\d{4}$/),
   )
 
   next()
@@ -145,7 +145,8 @@ export const validateUserSearch = (req, res, next) => {
       'nickname',
       validation.checkRegExp(/^[a-zA-Z0-9가-힣]+$/),
     )
-  isBanned && validation.check(isBanned, 'isBanned', validation.checkIsNumber())
+  isBanned &&
+    validation.check(isBanned, 'isBanned', validation.checkRegExp(/^0|1$/))
 
   next()
 }
@@ -156,6 +157,7 @@ export const validateUsername = (req, res, next) => {
   validation.check(
     username,
     'username',
+    validation.checkExist(),
     validation.checkRegExp(/^[a-z0-9]{7,30}$/),
   )
 

--- a/router/notice.js
+++ b/router/notice.js
@@ -1,7 +1,6 @@
 import express from 'express'
 import asyncify from 'express-asyncify'
 import { configDotenv } from 'dotenv'
-import * as validation from '@utility/validation'
 import { pgQuery } from '@database/postgres'
 import { requireAdminAuthority } from '@middleware/auth'
 import {
@@ -34,7 +33,7 @@ noticeRouter.post(
 )
 
 noticeRouter.get('/list', validatePageNumber, async (req, res) => {
-  const { page = 1 } = req.query
+  const { page } = req.query
 
   const result = (
     await pgQuery(
@@ -72,7 +71,7 @@ noticeRouter.get(
   validatePageNumber,
   validateNoticeSearch,
   async (req, res) => {
-    const { page = 1, q: keyword } = req.query
+    const { page, q: keyword } = req.query
 
     const result = (
       await pgQuery(
@@ -91,7 +90,6 @@ noticeRouter.get(
 
 noticeRouter.get('/:noticeId', validateNoticePathIndex, async (req, res) => {
   const { noticeId } = req.params
-  validation.check(noticeId, 'noticeId', validation.checkExist())
 
   const result = (
     await pgQuery(
@@ -116,13 +114,10 @@ noticeRouter.put(
   '/:noticeId',
   validateNoticePathIndex,
   requireAdminAuthority,
+  validateNotice,
   async (req, res) => {
     const { noticeId } = req.params
-    validation.check(noticeId, 'noticeId', validation.checkExist())
-
     const { title, content } = req.body
-    validation.check(title, 'title', validation.checkExist())
-    validation.check(content, 'content', validation.checkExist())
 
     await pgQuery(
       `UPDATE kkujjang.notice SET title=$1, content=$2 
@@ -136,16 +131,10 @@ noticeRouter.put(
 
 noticeRouter.delete(
   '/:noticeId',
-  validateNoticePathIndex,
   requireAdminAuthority,
+  validateNoticePathIndex,
   async (req, res) => {
     const { noticeId } = req.params
-    validation.check(noticeId, 'noticeId', validation.checkExist())
-
-    // TODO: remove line 117-119
-    const { title, content } = req.body
-    validation.check(title, 'title', validation.checkExist())
-    validation.check(content, 'content', validation.checkExist())
 
     await pgQuery(
       `UPDATE kkujjang.notice SET is_deleted=TRUE WHERE id=$1 AND is_deleted=FALSE`,

--- a/router/report.js
+++ b/router/report.js
@@ -1,7 +1,6 @@
 import express from 'express'
 import asyncify from 'express-asyncify'
 import { configDotenv } from 'dotenv'
-import * as validation from '@utility/validation'
 import { pgQuery } from '@database/postgres'
 import { requireAdminAuthority, requireSignin } from '@middleware/auth'
 import {
@@ -21,9 +20,9 @@ reportRouter.post('/', requireSignin, validateReport, async (req, res) => {
 
   const {
     reporteeId,
-    isOffensive = 0,
-    isPoorManner = 0,
-    isCheating = 0,
+    isOffensive,
+    isPoorManner,
+    isCheating,
     note = '',
   } = req.body
 
@@ -49,7 +48,7 @@ reportRouter.get(
   validatePageNumber,
   async (req, res) => {
     const {
-      page = 1,
+      page,
       reporterId = null,
       reporteeId = null,
       isOffensive = null,
@@ -138,6 +137,7 @@ reportRouter.get(
 reportRouter.put(
   '/:reportId',
   requireAdminAuthority,
+  validateReportPathIndex,
   validateReportModification,
   async (req, res) => {
     const { reportId } = req.params

--- a/router/user.js
+++ b/router/user.js
@@ -271,7 +271,7 @@ userRouter.get(
         [
           username === null ? '!' : `%${username}%`,
           nickname === null ? '!' : `%${nickname}%`,
-          isBanned === null ? 0 : `%${isBanned}%`,
+          isBanned === null ? 0 : isBanned,
         ],
       )
     ).rows

--- a/utility/validation.js
+++ b/utility/validation.js
@@ -14,12 +14,12 @@ const curry =
 // 하나의 값을 return 또는 throw해 줍니다.
 // 결국 iter를 하나의 값으로 압축했기 때문에 combine 함수입니다.
 const combine = (iter) => {
-  const funcs = iter[Symbol.iterator]()
+  const args = iter[Symbol.iterator]()
 
-  const target = funcs.next().value
-  const targetName = funcs.next().value
+  const target = args.next().value
+  const targetName = args.next().value
 
-  Array.from(funcs).forEach((func) => func(target, targetName))
+  Array.from(args).forEach((func) => func(target, targetName))
 }
 
 export const checkExist = curry((target, targetName) => {

--- a/utility/validation.js
+++ b/utility/validation.js
@@ -17,96 +17,78 @@ const combine = (iter) => {
   const funcs = iter[Symbol.iterator]()
 
   const target = funcs.next().value
-  const targetType = funcs.next().value
+  const targetName = funcs.next().value
 
-  const messages = Array.from(funcs).reduce((errors, func) => {
-    const result = func(target)
-    result.isValid !== true && errors.push(result.message)
-    return errors
-  }, [])
-
-  if (messages.length != 0) {
-    throw {
-      statusCode: 400,
-      message: `올바르지 않은 형식입니다: ${targetType}`,
-      messages,
-    }
-  }
+  Array.from(funcs).forEach((func) => func(target, targetName))
 }
 
-export const checkExist = curry((target) => {
-  let result = {
-    isValid: true,
+export const checkExist = curry((target, targetName) => {
+  if (target === '' || target === null || target === undefined) {
+    throw {
+      statusCode: 400,
+      message: `값이 존재하지 않습니다. (${targetName}: ${target})`,
+    }
   }
-  if (target != '' && target != null && target != undefined) {
-    return result
-  }
-  result.isValid = false
-  result.message = `checkExist: 값이 존재하지 않습니다.`
-  return result
 })
 
-export const checkLength = curry((min, max, target) => {
-  let result = {
-    isValid: true,
-  }
-  if (min <= target.length && target.length <= max) {
-    return result
-  }
-  result.isValid = false
+export const checkLength = curry((min, max, target, targetName) => {
   if (target.length < min) {
-    result.message = `checkLength: 길이가 너무 짧습니다.`
+    throw {
+      statusCode: 400,
+      message: `길이가 너무 짧습니다. (${targetName}: ${target})`,
+    }
   }
+
   if (max < target.length) {
-    result.message = `checkLength: 길이가 너무 깁니다.`
+    throw {
+      statusCode: 400,
+      message: `길이가 너무 깁니다. (${targetName}: ${target})`,
+    }
   }
-  return result
 })
 
-export const checkRegExp = curry((std, target) => {
-  let result = {
-    isValid: true,
+export const checkRegExp = curry((std, target, targetName) => {
+  if (!RegExp(std).test(target)) {
+    throw {
+      statusCode: 400,
+      message: `정규표현식(${std.toString()})과 일치하지 않습니다. (${targetName}: ${target})`,
+    }
   }
-  if (RegExp(std).test(target)) {
-    return result
-  }
-  result.isValid = false
-  result.message = `checkRegExp: 정규표현식과 일치하지 않습니다.`
-  return result
 })
 
-export const checkSame = curry((sameTarget, target) => {
-  let result = {
-    isValid: true,
+export const checkSame = curry((sameTarget, target, targetName) => {
+  if (target !== sameTarget) {
+    return `비교 대상(${sameTarget})과 일치하지 않는 값입니다. (${targetName}: ${target})`
   }
-  if (target == sameTarget) {
-    return result
-  }
-  result.isValid = false
-  result.message = `checkSame: 비교 대상 문자열과 동일하지 않은 문자열입니다.`
-  return result
 })
 
 const isNumberParsableString = (target) => /^\d+$/.test(target)
 
-export const checkIsNumberParsableString = curry((target) => {
-  return {
-    isValid: isNumberParsableString(target),
-    message: `checkIsNumber: 대상이 숫자가 아닙니다.`,
+export const checkIsNumberParsableString = curry((target, targetName) => {
+  if (!isNumberParsableString(target)) {
+    throw {
+      statusCode: 400,
+      message: `대상이 숫자가 아닙니다. (${targetName}: ${target})`,
+    }
   }
 })
 
 // min, max inclusive (>=, <=)
-export const checkParsedNumberInRange = curry((min, max, target) => {
-  const targetNumber = Number(target)
+export const checkParsedNumberInRange = curry(
+  (min, max, target, targetName) => {
+    const targetNumber = Number(target)
 
-  return {
-    isValid:
-      isNumberParsableString(target) &&
-      min <= targetNumber &&
-      targetNumber <= max,
-    message: `checkIsInRange: 대상(${target})이 숫자가 아니거나 범위를 벗어난 수입니다.`,
-  }
-})
+    if (
+      !isNumberParsableString(target) ||
+      targetNumber < min ||
+      targetNumber > max
+    ) {
+      throw {
+        statusCode: 400,
+        message: `숫자가 아니거나 범위 [${min}, ${max}]를 벗어난 수입니다. (${targetName}: ${target})`,
+      }
+    }
+  },
+)
 
 export const check = (...args) => combine(args)

--- a/utility/validation.js
+++ b/utility/validation.js
@@ -87,22 +87,25 @@ export const checkSame = curry((sameTarget, target) => {
   return result
 })
 
-const isNumber = (target) => {
-  return !isNaN(parseInt(target))
-}
+const isNumberParsableString = (target) => /^\d+$/.test(target)
 
-export const checkIsNumber = curry((target) => {
+export const checkIsNumberParsableString = curry((target) => {
   return {
-    isValid: isNumber(target),
+    isValid: isNumberParsableString(target),
     message: `checkIsNumber: 대상이 숫자가 아닙니다.`,
   }
 })
 
 // min, max inclusive (>=, <=)
-export const checkIsInNumberRange = curry((min, max, target) => {
+export const checkParsedNumberInRange = curry((min, max, target) => {
+  const targetNumber = Number(target)
+
   return {
-    isValid: isNumber(target) && min <= target && target <= max,
-    message: `checkIsInRange: 대상이 숫자가 아니거나 ${min} <= x <= ${max} 범위를 벗어난 수(${target})입니다.`,
+    isValid:
+      isNumberParsableString(target) &&
+      min <= targetNumber &&
+      targetNumber <= max,
+    message: `checkIsInRange: 대상(${target})이 숫자가 아니거나 범위를 벗어난 수입니다.`,
   }
 })
 


### PR DESCRIPTION
* `@utility/validation`은 request 검증에만 사용하도록 설계
* 숫자 입력 검증을 위해 정규식과 `Number()` 사용
* 검증 실패 시 바로 예외를 throw하도록 롤백